### PR TITLE
fix: adjust image paths for index.html

### DIFF
--- a/forthe50/templates/forthe50/index.html
+++ b/forthe50/templates/forthe50/index.html
@@ -61,7 +61,7 @@
         </div>
 
         <div class="col-lg-4 text-center">
-          <img src="src/assets/images/Trafficking-happening.jpg" alt="Icon" class="featurette-image img-fluid rounded">
+          <img src="{% static 'assets/Trafficking-happening.jpg' %}" alt="Icon" class="featurette-image img-fluid rounded">
         </div>
       </div>
 
@@ -72,7 +72,7 @@
       <div class="row gx-5  cards bg-light border-0 h-90 p-4">
 
         <div class="col-lg-4 text-center">
-          <img src="src/assets/images/Every-human-has-rights.jpg" alt="Icon" class="featurette-image img-fluid rounded">
+          <img src="{% static 'assets/Every-human-has-rights.jpg' %}" alt="Icon" class="featurette-image img-fluid rounded">
         </div>
         <div class="col-lg-8">
           <p class="text-left">
@@ -105,7 +105,7 @@
         </div>
 
         <div class="col-lg-4 text-center">
-          <img src="src/assets/images/Industrial-site.jpg" alt="Industrial site"
+          <img src="{% static 'assets/Industrial-site.jpg' %}" alt="Industrial site"
             class="featurette-image img-fluid rounded">
         </div>
 


### PR DESCRIPTION
This pull request includes updates to the `forthe50/templates/forthe50/index.html` file to improve the handling of static assets. The changes involve modifying the image source paths to use Django's `{% static %}` template tag.

Updates to image source paths:

* Updated the image source for "Trafficking-happening.jpg" to use the `{% static %}` template tag.
* Updated the image source for "Every-human-has-rights.jpg" to use the `{% static %}` template tag.
* Updated the image source for "Industrial-site.jpg" to use the `{% static %}` template tag.