### PR TITLE
fix: add missing brackets in css

### DIFF
--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -35,9 +35,11 @@ h1 {
 .logo-text:hover {
   color: var(--red);
   transform: scale(1.1);
+}
 
 .logo-text img {
   height: 40px;
+}
 
 h1 {
     font-size: 3rem;


### PR DESCRIPTION
This pull request includes a small change to the `backend/static/css/style.css` file. The change adds a closing brace to the `.logo-text:hover` and `.logo-text img` CSS rules.