### PR TITLE
fix: add about navlink to navbar, fix hrefs

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -61,10 +61,13 @@
                             <a class="nav-link {% if request.path == '/' %}active{% endif %} me-3" href="/">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link {% if request.path == '/about/' %}active{% endif %} me-3" href="/stories/">Stories</a>
+                            <a class="nav-link {% if request.path == '/about/' %}active{% endif %} me-3" href="{% url 'about' %}">About</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link {% if request.path == '/knowledge/' %}active{% endif %} me-3" href="/knowledge/">Knowledge</a>
+                            <a class="nav-link {% if request.path == '/stories/' %}active{% endif %} me-3" href="{% url 'stories' %}">Stories</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.path == '/knowledge/' %}active{% endif %} me-3" href="{% url 'knowledge' %}">Knowledge</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.path == '/statistics/' %}active{% endif %} me-3"


### PR DESCRIPTION
This pull request includes updates to the navigation links in the `templates/base.html` file to use Django's `{% url %}` template tag for better URL management.

Improvements to navigation links:

* Updated the "About" link to use `{% url 'about' %}` instead of a hardcoded URL.
* Updated the "Stories" link to use `{% url 'stories' %}` instead of a hardcoded URL.
* Added a new navigation item for "Knowledge" using `{% url 'knowledge' %}`.