### PR TITLE
chore: clean up style.css

### DIFF
--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -4,9 +4,9 @@
   --yellow: #ffeb3b;
   --red: #E41D24;
   --dark-red: #b1181d;
-  --burgundy: #1d0202;
+  --burgundy: #700000;
   --light-gray: #cacaca;
-  --medium-gray: #7c808d;
+  --medium-gray: #cccccc89;
   --dark-gray: #5e6572;
   --black: #000000;
 }
@@ -126,7 +126,7 @@ canvas {
   text-align: center;
   margin: 15px auto;
   box-sizing: border-box;
-  border: 1px solid #cccccc89; 
+  border: 1px solid var(--medium-gray); 
 }
 
 .card-header {
@@ -140,7 +140,7 @@ canvas {
 .card-header:first-child {
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
-  border-bottom: 1px solid #cccccc89; 
+  border-bottom: 1px solid var(--medium-gray); 
 }
 
 .card-body {
@@ -187,7 +187,7 @@ canvas {
 h1.page-header {
   font-size: 4rem;
   font-weight: 700;
-  color: #700000;
+  color: var(--burgundy);
   text-shadow: 2px 2px 4px rgba(255, 0, 0, 0.537);
   margin-bottom: 50px;
   text-align: center;
@@ -198,7 +198,7 @@ h1.page-header {
 .formHeader {
   font-size: 2.5rem;
   font-weight: 700;
-  color: #700000;
+  color: var(--burgundy);
   margin-bottom: 30px;
   text-align: center;
 }
@@ -213,7 +213,7 @@ h1.page-header {
 #reportForm .form-label {
   font-size: 0.8rem;
   font-weight: 500;
-  color: #1d0202;
+  color: var(--burgundy);
   margin-bottom: 5px;
 }
 
@@ -245,12 +245,9 @@ body.report-page .footer {
 /* -- Authorities disabled span -- */
 #disabled {
   font-size: 11px;
-  font-weight: bold;
   background-color: rgb(219, 194, 3);
   padding: 3px;
-  border-top: 1px solid #c0d7f1;
   text-align: right;
-  border-radius: 4px;
 }
 
 /* ------------------ Button Styles ------------------ */

--- a/forthe50/templates/forthe50/report.html
+++ b/forthe50/templates/forthe50/report.html
@@ -87,7 +87,7 @@
             </select>
           </div>
           <div class="mb-3">
-            <label for="authority" class="form-label">Authority* <span id="disabled">Only Testing Authority Enabled During the Hackathon</span></label>
+            <label for="authority" class="form-label">Authority* <span class="shadow fw-bold rounded" id="disabled">Only Testing Authority Enabled During the Hackathon</span></label>
             <select
               class="form-select"
               id="authority"


### PR DESCRIPTION
This pull request includes various updates to the CSS styling in the `backend/static/css/style.css` file and a minor HTML change in the `forthe50/templates/forthe50/report.html` file. The primary focus is on improving the maintainability and consistency of the CSS by using CSS variables and enhancing the styling of specific elements.

CSS variable updates:

* Updated the `--burgundy` color variable to a new shade (`#700000`) and the `--medium-gray` color variable to a more consistent shade (`#cccccc89`).

CSS styling improvements:

* Replaced hardcoded color values with CSS variables for the border of the `canvas` element and the `card-header` element.
* Updated the color of the `h1.page-header` and `.formHeader` elements to use the `--burgundy` CSS variable.
* Changed the color of the `#reportForm .form-label` element to use the `--burgundy` CSS variable.

HTML enhancement:

* Added additional classes (`shadow`, `fw-bold`, `rounded`) to the `#disabled` span element within the `label` for the `authority` field to improve its styling.